### PR TITLE
Fix requirement file (== instead of =) & yeelight version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Werkzeug==0.14.1
 gunicorn==19.9.0
 itsdangerous==0.24
 simplejson==3.16.0
-yeelight=0.4.2
-waitress=1.1.0
+yeelight==0.4.2
+waitress==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ Werkzeug==0.14.1
 gunicorn==19.9.0
 itsdangerous==0.24
 simplejson==3.16.0
-yeelight==0.4.2
+yeelight==0.4.3
 waitress==1.1.0


### PR DESCRIPTION
- Fix the requirement.txt file
- Bump version of yeelight to 0.4.3 from 0.4.2 to allow an alternative to fnctl to be used.